### PR TITLE
Send 404 headers when displaying 404 error pages

### DIFF
--- a/grawlix-cms-1.5.2/_system/GrlxPage2.php
+++ b/grawlix-cms-1.5.2/_system/GrlxPage2.php
@@ -17,6 +17,7 @@ class GrlxPage2 {
 	protected $templateFileList;
 	protected $template;
 	protected $path;
+	protected $statusCode;
 	protected $query;
 	protected $request;
 	protected $filebase;
@@ -48,10 +49,10 @@ class GrlxPage2 {
 		global $_db;
 		$this->db = $_db;
 
-		if ( $this->httpHeader )
+		/*if ( $this->httpHeader )
 		{
 			header($this->httpHeader);
-		}
+		}*/
 	}
 
 	/**
@@ -87,6 +88,11 @@ class GrlxPage2 {
 			if (is_numeric($route->u_id))
 			{
 				$this->u_id = $route->u_id;
+			}
+			
+			if(isset($route->statusCode))
+			{
+				$this->statusCode = $route->statusCode;
 			}
 
 			// Set the book_id
@@ -286,6 +292,7 @@ class GrlxPage2 {
 		if ( isset($_COOKIE['grlx_bar']) && $_COOKIE['grlx_bar'] == true ) {
 			$this->isAdmin = true;
 		}
+		if($this->statusCode == 404) header('HTTP/1.0 404 Not Found');
 		$this->getThemeToneInfo();
 		$this->buildSupportFileLinks();
 		$this->buildHeaderMeta();

--- a/grawlix-cms-1.5.2/_system/GrlxPage2_Comic.php
+++ b/grawlix-cms-1.5.2/_system/GrlxPage2_Comic.php
@@ -168,6 +168,7 @@ class GrlxPage2_Comic extends GrlxPage2 {
 		}
 		else {
 			// A quick page not found view for when a page outside of the published set is requested
+			$this->statusCode = 404;
 			$this->template = $this->templateFileList['static'];
 			$this->pageInfo['page_content']  = '<h2>Page '.$sortRequest.' not found!</h2>';
 			$this->pageInfo['page_content'] .= '<p>Maybe it doesn’t exist. Or maybe you’re not allowed to see it yet.</p>';

--- a/grawlix-cms-1.5.2/_system/GrlxPage2_Static.php
+++ b/grawlix-cms-1.5.2/_system/GrlxPage2_Static.php
@@ -45,6 +45,7 @@ class GrlxPage2_Static extends GrlxPage2 {
 		}
 
 		if ( !$this->pageInfo ) {
+			header('HTTP/1.0 404 Not Found');
 			die('<h1>Oops.</h1><p>Could not get page info for "'.$request->path.'".</p>');
 		}
 

--- a/grawlix-cms-1.5.2/_system/GrlxRoute2.php
+++ b/grawlix-cms-1.5.2/_system/GrlxRoute2.php
@@ -91,7 +91,7 @@ class GrlxRoute2 {
 	 * Match request to a route
 	 *
 	 * @param		object		request path and query
-	 * @return		object		controller and u_id
+	 * @return		object		controller and u_id, and possibly a statusCode
 	 */
 	public function getRoute($obj)
 	{
@@ -101,6 +101,8 @@ class GrlxRoute2 {
 		if (empty($match))
 		{
 			$match = $this->route['/404'];
+			$match = (object) $match;
+			$match->statusCode = 404;
 		}
 
 		return (object) $match;


### PR DESCRIPTION
Presently, Grawlix sends HTTP status code `200 OK` even when displaying error pages. With this PR, it sends 404 headers whenever:
- A comic page cannot be shown because it doesn't exist or isn't public yet
- A static page cannot be found (most invalid URLs lead to this).
- The page info for a given static page cannot be found (very rare, should only be due to errors in the database)

All the other page content is displayed as before, all that's different is the header.

I also commented out a check that sends a 200 header because it was never true anyway.

The 404 header (mostly) is sent in one place: GrlxPage2::buildPage(). The scenarios that cause it just set a `statusCode` property that's checked in that method. This means that it should be smooth to add this to any other error pages I may have missed, as well as adding headers for other error codes if the need arises.
The one exception is the 404 sent when page info cannot be found. I had to send it there as well because afterwards PHP just `die()`s.

The header is *not* sent in any case where Grawlix has no explicit error handling, such as requests to `/comic/non-numeric-ID` (Grawlix just shows the base page template with no content in these cases). These errors are very unlikely, but probably worth looking into handling at a later date.