### PR TITLE
Adds try/catch to checkExisting function

### DIFF
--- a/grawlix-cms/firstrun.php
+++ b/grawlix-cms/firstrun.php
@@ -173,10 +173,14 @@ class GrlxFirstRun {
 	 * Check for any existing users in db
 	 */
 	protected function checkExisting() {
-		$result = $this->db->query("SELECT level FROM grlx_user WHERE level > 1");
-		if ( $result->num_rows > 0 ) {
-			$this->error = 'The Grawlix CMS is already installed.';
-			return TRUE;
+		try {
+			$result = $this->db->query("SELECT level FROM grlx_user WHERE level > 1");
+			if ( $result->num_rows > 0 ) {
+				$this->error = 'The Grawlix CMS is already installed.';
+				return TRUE;
+			}
+		} catch (Exception $e) {
+			return FALSE;
 		}
 	}
 


### PR DESCRIPTION
Addresses issue #17 by implementing a try/catch wrapper inside checkExisting(). This function is called before the user is able to create a database, and did not contain any logic to address what to do if the database has not yet been entered. 