### PR TITLE
View unpublished pages as admin

### DIFF
--- a/grawlix-cms/_system/GrlxPage2.php
+++ b/grawlix-cms/_system/GrlxPage2.php
@@ -101,6 +101,29 @@ class GrlxPage2 {
 	}
 
 	/**
+	 * Check if page is being accessed by admin
+	 */
+	public function isAdmin() {
+		if ( empty($_SESSION['admin']) ) {	
+			return false;
+		}		
+		$isAdmin = false;
+		$maybe_serial = $_SESSION['admin'];		
+		$ucols = array('username','serial');
+		$result = $this->db-> get('user', null,$ucols);
+		foreach ( $result as $usr ) {
+			$maybe_admin = $usr['serial'];
+			if ($maybe_admin){
+				$isAdmin = $maybe_serial == $maybe_admin;		
+				if ($isAdmin){
+					break;
+				}
+			}
+		}
+		return isset($_COOKIE['grlx_bar']) && $isAdmin;
+	}
+	
+	/**
 	 * Set some vars from $grlxRequest
 	 *
 	 * @param		object		$grlxRequest
@@ -129,6 +152,7 @@ class GrlxPage2 {
 	 */
 	protected function getBookInfo($id = NULL) {
 		$id < 1 ? $id = 1 : $id;
+		$isAdmin = $this->isAdmin();
 
 		$cols = array(
 			'b.id',
@@ -145,7 +169,9 @@ class GrlxPage2 {
 		$this->db->join('path p', 'b.id = p.rel_id', 'INNER');
 		$this->db->where('p.rel_type', 'book');
 		$this->db->where('p.url', '/', '<>');
-		$this->db->where('bp.date_publish <= NOW()');
+		if ( !$isAdmin ) { // Clamp pages by date if not admin
+			$this->db->where('bp.date_publish <= NOW()');
+		}
 		$this->db->where('b.id', $id);
 		$this->db->orderBy('bp.sort_order', 'DESC');
 

--- a/grawlix-cms/_system/GrlxPage2_Comic.php
+++ b/grawlix-cms/_system/GrlxPage2_Comic.php
@@ -105,6 +105,7 @@ class GrlxPage2_Comic extends GrlxPage2 {
 	 * Get comic page info
 	 */
 	protected function getComicPage() {
+		$isAdmin = $this->isAdmin();
 		$cols = array(
 			'bp.id AS page_id',
 			'bp.title AS page_title',
@@ -119,7 +120,9 @@ class GrlxPage2_Comic extends GrlxPage2 {
 			'bp.date_publish',
 			'bp.options',
 		);
-		$this->db->where('date_publish <= NOW()');
+		if ( !$isAdmin ) { // Clamp pages by date if not admin
+			$this->db->where('date_publish <= NOW()');
+		}
 		$this->db->where('sort_order',$this->bookInfo['latest_page'],'<=');
 		$this->db->where('book_id',$this->bookInfo['id']);
 		if ( $this->where ) {
@@ -203,6 +206,16 @@ class GrlxPage2_Comic extends GrlxPage2 {
 			$this->getComicImages();
 			$this->getImageURL('0');
 			$this->formatComicParts();
+			
+			//Display notification if admin and page is in the future
+			if ( $isAdmin ) {
+				$pubDate = new DateTime($result['date_publish']);
+				$currentDate = new DateTime();
+				if ( $pubDate > $currentDate ) {
+					$difference = $pubDate->diff($currentDate);
+					print ('<div id="special" style="position: fixed;width: 80%;top: 80px;left: 10%;border: #a582ff dashed 3px;z-index: 999;">This page isn\'t publically accessible yet.<br>It will be published in <b>'.$difference->format('%a days, %h hours, %i minutes').'.</b><br>You can view it because you\'ve logged in as admin.</div>');
+				}
+			}
 		}
 		else {
 			// A quick page not found view for when a page outside of the published set is requested


### PR DESCRIPTION
If you're logged in as admin, you can view pages whose publish date is set in the future. It also displays popup that reminds you that the page isn't live yet:
<img width="1897" height="330" alt="image" src="https://github.com/user-attachments/assets/d6e68e72-b1e2-4938-a017-a0ef8dee4ec4" />
