### PR TITLE
GrlxRequest.php: Don't lose the sort_order when query params are present

### DIFF
--- a/grawlix-cms/_system/GrlxPage2_Comic.php
+++ b/grawlix-cms/_system/GrlxPage2_Comic.php
@@ -28,13 +28,10 @@ class GrlxPage2_Comic extends GrlxPage2 {
 	{
 		parent::contents($request);
 
-		if (is_array($request->query))
+		if (is_array($request->query) && array_key_exists('sort_order', $request->query))
 		{
 			// Get a page by its sort order
-			if (array_key_exists('sort_order', $request->query))
-			{
-				$this->where['sort_order'] = $request->query['sort_order'];
-			}
+			$this->where['sort_order'] = $request->query['sort_order'];
 			$this->getComicPage();
 		}
 		// Load comic home

--- a/grawlix-cms/_system/GrlxPage2_Comic.php
+++ b/grawlix-cms/_system/GrlxPage2_Comic.php
@@ -28,7 +28,7 @@ class GrlxPage2_Comic extends GrlxPage2 {
 	{
 		parent::contents($request);
 
-		if (is_array($request->query) && array_key_exists('sort_order', $request->query))
+		if (is_array($request->query) && array_key_exists('sort_order', $request->query) && $request->query['sort_order'] > 0)
 		{
 			// Get a page by its sort order
 			$this->where['sort_order'] = $request->query['sort_order'];

--- a/grawlix-cms/_system/GrlxRequest.php
+++ b/grawlix-cms/_system/GrlxRequest.php
@@ -29,7 +29,10 @@ class GrlxRequest {
 				{
 					// Make an array of query vars
 					parse_str($val, $array);
-					$this->$var = $array;
+					if(isset($this->$var)) //If there's something already there (e.g. the sort_order), don't overwrite it!
+						array_merge($this->$var, $array);
+					else
+						$this->$var = $array;
 				}
 
 				if ($var == 'path')


### PR DESCRIPTION
Always overwriting the query was causing any previously-parsed sort_order to be lost (because that's also stored in the query variable), which caused the wrong comic page to display when requesting a specific comic page with additional parameters (such as utm params).

Resolves #42